### PR TITLE
Fixed: testmodule IP does not respond on port 443

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -4,7 +4,7 @@ import port_scanner
 print("***Tests***")
 class UnitTests(unittest.TestCase):
     def test_port_scanner_ip(self):
-        ports = port_scanner.get_open_ports("209.216.230.240", [440, 445], False)
+        ports = port_scanner.get_open_ports("104.26.10.78", [440, 445], False)
         actual = ports
         expected = [443]
         self.assertEqual(actual, expected, 'Expected scanning ports of IP address to return [443].')


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

IP 209.216.230.240 did not respond on port 443, I changed it to an address that worked on https port, and also didn't respond on any other port in range 440-445. The IP address I inserted is just an address from the tests below in the same file.
